### PR TITLE
[frontend] add skeleton permissions page

### DIFF
--- a/nwc-frontend/src/LayoutInnerContent.tsx
+++ b/nwc-frontend/src/LayoutInnerContent.tsx
@@ -12,6 +12,8 @@ export function LayoutInnerContent({ children }: Props) {
 }
 
 const Container = styled.div`
+  display: flex;
+  flex-direction: column;
   margin-top: ${Spacing["6xl"]};
   max-width: 800px;
   width: 100%;

--- a/nwc-frontend/src/Root.tsx
+++ b/nwc-frontend/src/Root.tsx
@@ -10,6 +10,7 @@ import { Nav } from "./Nav";
 import { NotificationLayout } from "./NotificationLayout";
 import { LayoutInnerContent } from "./LayoutInnerContent";
 import GlobalNotificationContext from "src/hooks/useGlobalNotificationContext";
+import { PermissionsPage } from "./permissions/PermissionsPage";
 
 const router = createBrowserRouter([
   {
@@ -20,6 +21,10 @@ const router = createBrowserRouter([
     path: "/connection/:appId",
     element: <ConnectionPage />,
   },
+  {
+    path: "/permissions/:appId",
+    element: <PermissionsPage />,
+  }
 ]);
 
 export function Root() {

--- a/nwc-frontend/src/components/Uma.tsx
+++ b/nwc-frontend/src/components/Uma.tsx
@@ -23,7 +23,6 @@ const Container = styled.div`
   flex-direction: row;
   gap: 6px;
   align-items: center;
-  justify-content: center;
   width: 100%;
 `;
 

--- a/nwc-frontend/src/hooks/useConnection.ts
+++ b/nwc-frontend/src/hooks/useConnection.ts
@@ -1,0 +1,82 @@
+import { useEffect, useState } from "react";
+import { Connection } from "src/types/Connection";
+import { Currency } from "src/types/Currency";
+
+export const useConnection = ({ appId }: { appId: string }) => {
+  const [connection, setConnection] = useState<Connection>();
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+
+  useEffect(() => {
+    // eslint-disable-next-line @typescript-eslint/require-await
+    async function fetchConnection() {
+      try {
+        // const response = await fetch("/connection");
+        // const connection = await response.json();
+        setIsLoading(true);
+        const connection = {
+          appId: "1",
+          name: "Cool App",
+          domain: "coolapp.com",
+          verified: true,
+          createdAt: new Date().toISOString(),
+          lastUsed: new Date().toISOString(),
+          avatar: "/uma.svg",
+          permissions: [
+            {
+              type: "READ_BALANCE",
+              description: "Read your balance",
+            },
+            {
+              type: "READ_TRANSACTIONS",
+              description: "Read transaction history",
+            },
+            {
+              type: "SEND_PAYMENTS",
+              description: "Send payments from your UMA",
+            },
+          ],
+          amountPerMonthLowestDenom: 200,
+          currency: {
+            symbol: "$",
+            name: "US Dollar",
+            decimals: 2,
+          } as Currency,
+          isActive: false,
+        } as Connection;
+        setConnection(connection);
+      } catch (e) {
+        console.error(e);
+      }
+
+      setIsLoading(false);
+    }
+      
+    let ignore = false;
+    fetchConnection();
+    return () => {
+      ignore = true;
+    };
+  }, [appId]);
+
+  // eslint-disable-next-line @typescript-eslint/require-await
+  const updateConnection = async ({ amountPerMonthLowestDenom }: { amountPerMonthLowestDenom: number }) => {
+    try {
+      // await fetch("/connection", {
+      //   method: "POST",
+      //   body: JSON.stringify({ appId: connection.appId, amountPerMonthLowestDenom }),
+      // });
+      setConnection({
+        ...connection,
+        amountPerMonthLowestDenom,
+      });
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  return {
+    connection,
+    isLoading,
+    updateConnection,
+  };
+};

--- a/nwc-frontend/src/hooks/useConnections.ts
+++ b/nwc-frontend/src/hooks/useConnections.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { fetchConnections } from "src/utils/fetchConnections";
+import { Connection, fetchConnections } from "src/utils/fetchConnections";
 
 export function useConnections() {
   const [connections, setConnections] = useState<Connection[]>();

--- a/nwc-frontend/src/permissions/PermissionsPage.tsx
+++ b/nwc-frontend/src/permissions/PermissionsPage.tsx
@@ -1,0 +1,214 @@
+import styled from "@emotion/styled";
+import { Button, Icon, UnstyledButton } from "@lightsparkdev/ui/components";
+import { Label } from "@lightsparkdev/ui/components/typography/Label";
+import { Title } from "@lightsparkdev/ui/components/typography/Title";
+import { Spacing } from "@lightsparkdev/ui/styles/tokens/spacing";
+import { Avatar } from "src/components/Avatar";
+import { Uma } from "src/components/Uma";
+import { useConnection } from "src/hooks/useConnection";
+import { useUma } from "src/hooks/useUma";
+import { convertToNormalDenomination } from "src/utils/convertToNormalDenomination";
+
+
+export const PermissionsPage = ({ appId }: { appId: string }) => {
+  const { connection, updateConnection, isLoading: isLoadingConnection } = useConnection({ appId });
+  const { uma, isLoading: isLoadingUma } = useUma();
+
+  if (isLoadingConnection || isLoadingUma) {
+    return (
+      <Container>
+        <Title content="Loading..." />
+      </Container>
+    )
+  }
+
+  const { 
+    name,
+    domain,
+    createdAt,
+    lastUsed,
+    avatar,
+    permissions,
+    amountPerMonthLowestDenom,
+    currency,
+    verified,
+  } = connection;
+
+  const handleEdit = () => {
+    // TODO: Implement edit permissions
+    console.log("Edit permissions");
+  }
+
+  const header = (
+    <Header>
+      <VaspLogo src="/vasp.svg" width={32} height={32} />
+      <UnstyledButton>
+        <Icon name="Close" width={8} />
+      </UnstyledButton>
+    </Header>
+  )
+  return (
+    <Container>
+      {header}
+      <Intro>
+        <Title content="Connect your UMA" />
+        <Uma uma={uma} />
+      </Intro>
+
+      <PermissionsContainer>
+        <PermissionsDescription>
+          <AppSection>
+            <Avatar src={avatar} size={48} />
+            <AppDetails>
+              <AppName>
+                {name}
+                {verified ? (<VerifiedBadge>
+                  <Icon name="CheckmarkCircleTier3" width={20}/>
+                </VerifiedBadge>) : null}
+              </AppName>
+              <AppDomain>{domain}</AppDomain>
+            </AppDetails>
+          </AppSection>
+          <Permissions>
+            <Label size="Large" content="Would like to" />
+            <PermissionList>
+              {permissions.map((permission) => (
+                <Permission key={permission}>
+                  <Icon name="CheckmarkCircleTier1" width={16}/>
+                  {permission.description}
+                </Permission>
+              ))}
+            </PermissionList>
+          </Permissions>
+        </PermissionsDescription>
+        <Limit onClick={handleEdit}>
+          <LimitDescription>{`${currency.symbol}${convertToNormalDenomination(amountPerMonthLowestDenom, currency)}/month spending limit`}</LimitDescription>
+          <Icon name="Pencil" width={12} />
+        </Limit>
+      </PermissionsContainer>
+
+      <ButtonSection>
+        <Button text="Connect UMA" kind="primary" fullWidth />
+        <Button text="Cancel" kind="secondary" fullWidth />
+      </ButtonSection>
+    </Container>
+  )
+}
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-self: center;
+  gap: 24px;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+
+  max-width: 345px;
+`;
+
+const Header = styled.div`
+  display: flex;
+  flex-direction: row;
+  width: 100%;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+const VaspLogo = styled.img`
+`;
+
+const Intro = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${Spacing.xs};
+  width: 100%;
+`;
+
+const PermissionsContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  border: 0.5px solid #C0C9D6;
+  border-radius: 8px;
+`;
+
+const PermissionsDescription = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${Spacing.xl};
+  width: 100%;
+  border-bottom: 0.5px solid #C0C9D6;
+  padding: ${Spacing.lg};
+`;
+
+const AppSection = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 16px;
+  align-items: center;
+`;
+
+const AppDetails = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+`;
+
+const AppName = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 4px;
+`;
+
+const AppDomain = styled.div`
+  color: #686a72;
+  font-size: 14px;
+`;
+
+const VerifiedBadge = styled.div`
+  color: #00d4ff;
+  font-size: 12px;
+`;
+
+const Permissions = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${Spacing.sm};
+`;
+
+const PermissionList = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+`;
+
+const Permission = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 4px;
+`;
+
+const Limit = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  padding: ${Spacing.lg};
+  cursor: pointer;
+`;
+
+const LimitDescription = styled.div`
+  color: #686a72;
+  font-size: 16px;
+`;
+
+const ButtonSection = styled.div`
+  display: flex;
+  flex-direction: column;
+  max-width: 345px;
+  width: 100%;
+  gap: 16px;
+`;

--- a/nwc-frontend/src/types/Connection.ts
+++ b/nwc-frontend/src/types/Connection.ts
@@ -1,0 +1,19 @@
+interface Permission {
+  type: string;
+  description: string;
+  optional?: boolean;
+}
+
+export interface Connection {
+  appId: string;
+  name: string;
+  domain: string;
+  verified: boolean;
+  createdAt: string;
+  lastUsed: string;
+  avatar: string;
+  permissions: Permission[];
+  amountPerMonthLowestDenom: number;
+  currency: Currency;
+  isActive: boolean;
+}

--- a/nwc-frontend/src/types/Currency.ts
+++ b/nwc-frontend/src/types/Currency.ts
@@ -1,0 +1,7 @@
+export interface Currency {
+  code: string;
+  name: string;
+  symbol: string;
+  decimals: number;
+  type: string;
+}

--- a/nwc-frontend/src/utils/fetchConnections.ts
+++ b/nwc-frontend/src/utils/fetchConnections.ts
@@ -1,10 +1,4 @@
-export interface Connection {
-  appId: string;
-  name: string;
-  createdAt: string;
-  lastUsed: string;
-  avatar: string;
-}
+import { Connection } from "src/types/Connection";
 
 // eslint-disable-next-line @typescript-eslint/require-await
 export const fetchConnections = async () => {


### PR DESCRIPTION
![Screenshot 2024-07-18 at 5 53 32 PM](https://github.com/user-attachments/assets/2e0bfdb6-8463-4c83-97dc-49398b1d12d5)

- adds a permissions page/route
- mocks data for now