### PR TITLE
[frontend] add permissions list to connection management page

### DIFF
--- a/nwc-frontend/src/connections/ConnectionPage.tsx
+++ b/nwc-frontend/src/connections/ConnectionPage.tsx
@@ -4,15 +4,30 @@ import { colors } from "@lightsparkdev/ui/styles/colors";
 import { Spacing } from "@lightsparkdev/ui/styles/tokens/spacing";
 import { TransactionTable } from "src/components/TransactionTable";
 import { Header } from "./Header";
+import { PermissionsList } from "src/permissions/PermissionsList";
+import { useConnection } from "src/hooks/useConnection";
+import { Shimmer } from "src/components/Shimmer";
 
 export default function ConnectionPage({ appId }: { appId: string }) {
+  const { connection, isLoading: isLoadingConnection } = useConnection({ appId });
+
   return (
     <Main>
       <Header />
-      <Title content="Permissions" />
-      <Title content="Spending limit" />
-      <Title content="Transactions" />
-      <TransactionTable appId={appId} />
+      <Content>
+        <Section>
+          <Title content="Permissions" />
+          {isLoadingConnection ? <Shimmer width={200} height={20} /> : <PermissionsList permissions={connection.permissions} />}
+        </Section>
+        <Section>
+          <Title content="Spending limit" />
+
+        </Section>
+        <Section>
+          <Title content="Transactions" />
+          <TransactionTable appId={appId} />
+        </Section>
+      </Content>
     </Main>
   );
 }
@@ -22,7 +37,25 @@ const Main = styled.main`
   flex-direction: column;
   width: 100%;
   height: 100%;
-  background: ${colors.white};
-  padding: ${Spacing.md} ${Spacing["2xl"]};
+`;
+
+const Content = styled.div`
+  display: flex;
+  flex-direction: column;
+
   border-radius: 24px;
+  background: ${colors.white};
+`;
+
+const Section = styled.section`
+  display: flex;
+  flex-direction: column;
+  gap: ${Spacing.lg};
+  width: 100%;
+  padding: ${Spacing["2xl"]} ${Spacing["2xl"]};
+
+  &:not(:last-child) {
+    border-bottom: 1px solid ${colors.gray90};
+    padding-bottom: ${Spacing["2xl"]};
+  }
 `;

--- a/nwc-frontend/src/permissions/PermissionsList.tsx
+++ b/nwc-frontend/src/permissions/PermissionsList.tsx
@@ -1,0 +1,32 @@
+import styled from "@emotion/styled";
+import { Icon } from "@lightsparkdev/ui/components";
+import { Spacing } from "@lightsparkdev/ui/styles/tokens/spacing";
+import { Permission } from "src/types/Connection"
+
+
+export const PermissionsList = ({ permissions }: Permission[]) => {
+  return (
+    <List>
+      {permissions.map((permission) => (
+        <PermissionRow key={permission}>
+          <Icon name="CheckmarkCircleTier1" width={16}/>
+          {permission.description}
+        </PermissionRow>
+      ))}
+    </List>
+  );
+}
+
+const List = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${Spacing["3xs"]};
+  width: 100%;
+`;
+
+const PermissionRow = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: ${Spacing["3xs"]};
+`;

--- a/nwc-frontend/src/permissions/PermissionsPage.tsx
+++ b/nwc-frontend/src/permissions/PermissionsPage.tsx
@@ -12,6 +12,7 @@ import { LimitFrequency } from "src/types/Connection";
 import { convertToNormalDenomination } from "src/utils/convertToNormalDenomination";
 import { formatConnectionString } from "src/utils/formatConnectionString";
 import { EditLimit } from "./EditLimit";
+import { PermissionsList } from "./PermissionsList";
 
 
 export const PermissionsPage = ({ appId }: { appId: string }) => {
@@ -83,14 +84,7 @@ export const PermissionsPage = ({ appId }: { appId: string }) => {
           </AppSection>
           <Permissions>
             <Label size="Large" content="Would like to" />
-            <PermissionList>
-              {permissions.map((permission) => (
-                <Permission key={permission}>
-                  <Icon name="CheckmarkCircleTier1" width={16}/>
-                  {permission.description}
-                </Permission>
-              ))}
-            </PermissionList>
+            <PermissionsList permissions={permissions} />
           </Permissions>
         </PermissionsDescription>
         <Limit onClick={handleEdit}>
@@ -201,19 +195,6 @@ const Permissions = styled.div`
   display: flex;
   flex-direction: column;
   gap: ${Spacing.sm};
-`;
-
-const PermissionList = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-`;
-
-const Permission = styled.div`
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  gap: 4px;
 `;
 
 const Limit = styled.div`

--- a/nwc-frontend/src/types/Connection.ts
+++ b/nwc-frontend/src/types/Connection.ts
@@ -1,4 +1,4 @@
-interface Permission {
+export interface Permission {
   type: string;
   description: string;
   optional?: boolean;


### PR DESCRIPTION
![Screenshot 2024-07-22 at 1 05 41 PM](https://github.com/user-attachments/assets/6156fb08-be5f-4f4d-ae4c-a0afe17645c9)

- refactored permissions list so that it can be used here and in the initial connection UI