### PR TITLE
[frontend] add personalize connection settings page

### DIFF
--- a/nwc-frontend/src/hooks/useConnection.ts
+++ b/nwc-frontend/src/hooks/useConnection.ts
@@ -1,5 +1,9 @@
 import { useEffect, useState } from "react";
-import { Connection, LimitFrequency } from "src/types/Connection";
+import {
+  Connection,
+  LimitFrequency,
+  PermissionType,
+} from "src/types/Connection";
 
 export const useConnection = ({ appId }: { appId: string }) => {
   const [connection, setConnection] = useState<Connection>();
@@ -22,16 +26,18 @@ export const useConnection = ({ appId }: { appId: string }) => {
           avatar: "/uma.svg",
           permissions: [
             {
-              type: "READ_BALANCE",
-              description: "Read your balance",
-            },
-            {
-              type: "READ_TRANSACTIONS",
-              description: "Read transaction history",
-            },
-            {
-              type: "SEND_PAYMENTS",
+              type: PermissionType.SEND_PAYMENTS,
               description: "Send payments from your UMA",
+            },
+            {
+              type: PermissionType.READ_BALANCE,
+              description: "Read your balance",
+              optional: true,
+            },
+            {
+              type: PermissionType.READ_TRANSACTIONS,
+              description: "Read transaction history",
+              optional: true,
             },
           ],
           amountInLowestDenom: 200,
@@ -99,4 +105,19 @@ export const useConnection = ({ appId }: { appId: string }) => {
     isLoading,
     updateConnection,
   };
+};
+
+// eslint-disable-next-line @typescript-eslint/require-await
+export const initializeConnection = async (connection: Connection) => {
+  try {
+    // const response = await fetch("/connection", {
+    //   method: "POST",
+    //   body: JSON.stringify({ ...connection, }),
+    // });
+    console.log("Connection initialized", connection);
+    return true;
+  } catch (e) {
+    console.error(e);
+    return false;
+  }
 };

--- a/nwc-frontend/src/permissions/PermissionsEditableList.tsx
+++ b/nwc-frontend/src/permissions/PermissionsEditableList.tsx
@@ -1,0 +1,58 @@
+import styled from "@emotion/styled";
+import { Checkbox } from "@lightsparkdev/ui/components";
+import { Spacing } from "@lightsparkdev/ui/styles/tokens/spacing";
+import { PermissionState } from "src/types/Connection";
+
+interface Props {
+  permissionStates: PermissionState[];
+  updatePermissionStates: (permissionStates: PermissionState[]) => void;
+}
+
+export const PermissionsEditableList = ({
+  permissionStates,
+  updatePermissionStates,
+}: Props) => {
+  const handleCheckboxChange = (permissionState: PermissionState) => () => {
+    const isEnabled = !permissionState.enabled;
+    updatePermissionStates(
+      permissionStates.map((ps) => {
+        if (ps.permission.type === permissionState.permission.type) {
+          return {
+            ...ps,
+            enabled: isEnabled,
+          };
+        }
+        return ps;
+      }),
+    );
+  };
+
+  return (
+    <List>
+      {permissionStates.map((permissionState) => (
+        <PermissionRow key={permissionState.permission.type}>
+          <Checkbox
+            checked={permissionState.enabled}
+            onChange={handleCheckboxChange(permissionState)}
+            disabled={!permissionState.permission.optional}
+          />
+          {permissionState.permission.description}
+        </PermissionRow>
+      ))}
+    </List>
+  );
+};
+
+const List = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${Spacing["3xs"]};
+  width: 100%;
+`;
+
+const PermissionRow = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: ${Spacing["3xs"]};
+`;

--- a/nwc-frontend/src/permissions/PersonalizePage.tsx
+++ b/nwc-frontend/src/permissions/PersonalizePage.tsx
@@ -1,0 +1,229 @@
+import styled from "@emotion/styled";
+import { Button, Icon } from "@lightsparkdev/ui/components";
+import { Label } from "@lightsparkdev/ui/components/typography/Label";
+import { colors } from "@lightsparkdev/ui/styles/colors";
+import { Spacing } from "@lightsparkdev/ui/styles/tokens/spacing";
+import { useState } from "react";
+import { Avatar } from "src/components/Avatar";
+import {
+  Connection,
+  ExpirationPeriod,
+  LimitFrequency,
+  PermissionState,
+} from "src/types/Connection";
+import { formatConnectionString } from "src/utils/formatConnectionString";
+import { EditLimit } from "./EditLimit";
+import { PermissionsEditableList } from "./PermissionsEditableList";
+
+export interface ConnectionSettings {
+  permissionStates: PermissionState[];
+  amountInLowestDenom: number;
+  limitFrequency: LimitFrequency;
+  limitEnabled: boolean;
+  expirationPeriod: ExpirationPeriod;
+}
+
+interface Props {
+  connection: Connection;
+  connectionSettings: ConnectionSettings;
+  updateConnectionSettings: (connectionSettings: ConnectionSettings) => void;
+  onBack: () => void;
+  onReset: () => void;
+}
+
+export const PersonalizePage = ({
+  connection,
+  connectionSettings,
+  updateConnectionSettings,
+  onBack,
+  onReset,
+}: Props) => {
+  const [isEditLimitVisible, setIsEditLimitVisible] = useState<boolean>(false);
+  const [internalConnectionSettings, setInternalConnectionSettings] =
+    useState<ConnectionSettings>(connectionSettings);
+
+  const { name, domain, avatar, currency, verified } = connection;
+
+  const handleEdit = () => {
+    setIsEditLimitVisible(true);
+  };
+
+  const handleSubmitEditLimit = ({
+    amountInLowestDenom,
+    frequency,
+    enabled,
+  }: {
+    amountInLowestDenom: number;
+    frequency: LimitFrequency;
+    enabled: boolean;
+  }) => {
+    setInternalConnectionSettings({
+      ...internalConnectionSettings,
+      amountInLowestDenom,
+      limitFrequency: frequency,
+      limitEnabled: enabled,
+    });
+    setIsEditLimitVisible(false);
+  };
+
+  const handleUpdatePermissionStates = (
+    permissionStates: PermissionState[],
+  ) => {
+    setInternalConnectionSettings({
+      ...internalConnectionSettings,
+      permissionStates,
+    });
+  };
+
+  const handleSubmit = () => {
+    updateConnectionSettings(internalConnectionSettings);
+  };
+
+  return (
+    <Container>
+      <PermissionsContainer>
+        <PermissionsDescription>
+          <AppSection>
+            <Avatar src={avatar} size={48} />
+            <AppDetails>
+              <AppName>
+                {name}
+                {verified ? (
+                  <VerifiedBadge>
+                    <Icon name="CheckmarkCircleTier3" width={20} />
+                  </VerifiedBadge>
+                ) : null}
+              </AppName>
+              <AppDomain>{domain}</AppDomain>
+            </AppDetails>
+          </AppSection>
+          <Permissions>
+            <Label size="Large" content="Would like to" />
+            <PermissionsEditableList
+              permissionStates={internalConnectionSettings.permissionStates}
+              updatePermissionStates={handleUpdatePermissionStates}
+            />
+          </Permissions>
+        </PermissionsDescription>
+        <Limit onClick={handleEdit}>
+          <LimitDescription>
+            {internalConnectionSettings.limitEnabled
+              ? `${formatConnectionString({ currency, limitFrequency: internalConnectionSettings.limitFrequency, amountInLowestDenom: internalConnectionSettings.amountInLowestDenom })} spending limit`
+              : "No spending limit"}
+          </LimitDescription>
+          <Icon name="Pencil" width={12} />
+        </Limit>
+      </PermissionsContainer>
+
+      <ButtonSection>
+        <Button
+          text="Update permissions"
+          kind="primary"
+          fullWidth
+          onClick={handleSubmit}
+        />
+        <Button text="Reset" kind="secondary" fullWidth onClick={onReset} />
+      </ButtonSection>
+
+      <EditLimit
+        title="Spending limit"
+        visible={isEditLimitVisible}
+        amountInLowestDenom={internalConnectionSettings.amountInLowestDenom}
+        currency={currency}
+        limitFrequency={internalConnectionSettings.limitFrequency}
+        frequency={internalConnectionSettings.limitFrequency}
+        enabled={internalConnectionSettings.limitEnabled}
+        handleSubmit={handleSubmitEditLimit}
+        handleCancel={() => setIsEditLimitVisible(false)}
+      />
+    </Container>
+  );
+};
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-self: center;
+  gap: 24px;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+
+  max-width: 345px;
+`;
+
+const PermissionsContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  border: 0.5px solid #c0c9d6;
+  border-radius: 8px;
+  background: ${colors.white};
+`;
+
+const PermissionsDescription = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${Spacing.xl};
+  width: 100%;
+  border-bottom: 0.5px solid #c0c9d6;
+  padding: ${Spacing.lg};
+`;
+
+const AppSection = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 16px;
+  align-items: center;
+`;
+
+const AppDetails = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+`;
+
+const AppName = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 4px;
+`;
+
+const AppDomain = styled.div`
+  color: #686a72;
+  font-size: 14px;
+`;
+
+const VerifiedBadge = styled.div`
+  color: #00d4ff;
+  font-size: 12px;
+`;
+
+const Permissions = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${Spacing.sm};
+`;
+
+const Limit = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  padding: ${Spacing.lg};
+  cursor: pointer;
+`;
+
+const LimitDescription = styled.div`
+  color: #686a72;
+  font-size: 16px;
+`;
+
+const ButtonSection = styled.div`
+  display: flex;
+  flex-direction: column;
+  max-width: 345px;
+  width: 100%;
+  gap: 16px;
+`;

--- a/nwc-frontend/src/types/Connection.ts
+++ b/nwc-frontend/src/types/Connection.ts
@@ -1,15 +1,32 @@
 import { Currency } from "./Currency";
 
+export enum PermissionType {
+  SEND_PAYMENTS = "SEND_PAYMENTS",
+  READ_BALANCE = "READ_BALANCE",
+  READ_TRANSACTIONS = "READ_TRANSACTIONS",
+}
+
 export interface Permission {
-  type: string;
+  type: PermissionType;
   description: string;
   optional?: boolean;
+}
+
+export interface PermissionState {
+  permission: Permission;
+  enabled: boolean;
 }
 
 export enum LimitFrequency {
   DAILY = "Daily",
   WEEKLY = "Weekly",
   MONTHLY = "Monthly",
+}
+
+export enum ExpirationPeriod {
+  WEEK = "Week",
+  MONTH = "Month",
+  YEAR = "Year",
 }
 
 export interface Connection {
@@ -20,6 +37,7 @@ export interface Connection {
   createdAt: string;
   lastUsed: string;
   disconnectedAt: string;
+  expiration: string;
   avatar: string;
   permissions: Permission[];
   amountInLowestDenom: number;


### PR DESCRIPTION
- adds personalize page 
- refactored initial permissions page to keep track of connection settings and call a different initialize connection function
- not all the pieces of the page yet; will come in later PRs

![Screenshot 2024-07-26 at 5 56 29 PM](https://github.com/user-attachments/assets/83e3183e-9e3b-43bd-bd77-6d405810db78)

![Screenshot 2024-07-26 at 6 01 38 PM](https://github.com/user-attachments/assets/3457a1c4-a2ca-4386-b96d-7ad9b69d80d7)

![Screenshot 2024-07-26 at 6 01 42 PM](https://github.com/user-attachments/assets/190f3a40-dce0-46b7-adbd-f7e23d1e2476)
