### PR TITLE
[frontend] show spend limit and expiration as permissions

### DIFF
--- a/nwc-frontend/src/permissions/PermissionsList.tsx
+++ b/nwc-frontend/src/permissions/PermissionsList.tsx
@@ -3,15 +3,30 @@ import { Icon } from "@lightsparkdev/ui/components";
 import { Spacing } from "@lightsparkdev/ui/styles/tokens/spacing";
 import { Permission } from "src/types/Connection";
 
-export const PermissionsList = ({ permissions }: Permission[]) => {
+export const PermissionsList = ({
+  permissions,
+}: {
+  permissions: (Permission | string)[];
+}) => {
   return (
     <List>
-      {permissions.map((permission) => (
-        <PermissionRow key={permission}>
-          <Icon name="CheckmarkCircleTier1" width={16} />
-          {permission.description}
-        </PermissionRow>
-      ))}
+      {permissions.map((permission) => {
+        if (typeof permission === "string") {
+          return (
+            <PermissionRow key={permission}>
+              <Icon name="CheckmarkCircleTier1" width={16} />
+              {permission}
+            </PermissionRow>
+          );
+        }
+
+        return (
+          <PermissionRow key={permission.type}>
+            <Icon name="CheckmarkCircleTier1" width={16} />
+            {permission.description}
+          </PermissionRow>
+        );
+      })}
     </List>
   );
 };

--- a/nwc-frontend/src/permissions/PermissionsPage.tsx
+++ b/nwc-frontend/src/permissions/PermissionsPage.tsx
@@ -13,8 +13,10 @@ import { useUma } from "src/hooks/useUma";
 import {
   ExpirationPeriod,
   LimitFrequency,
+  Permission,
   PermissionType,
 } from "src/types/Connection";
+import { formatConnectionString } from "src/utils/formatConnectionString";
 import { PermissionsList } from "./PermissionsList";
 import { ConnectionSettings, PersonalizePage } from "./PersonalizePage";
 
@@ -145,6 +147,21 @@ export const PermissionsPage = ({ appId, clientAppDefaultSettings }: Props) => {
     );
   }
 
+  const permissions: (Permission | string)[] =
+    connectionSettings.permissionStates
+      .filter((permissionState) => permissionState.enabled)
+      .map((permissionState) => permissionState.permission);
+  if (connectionSettings.limitEnabled) {
+    permissions.push(
+      `Set a ${formatConnectionString({ currency, limitFrequency: connectionSettings.limitFrequency, amountInLowestDenom: connectionSettings.amountInLowestDenom })} spend limit`,
+    );
+  }
+  if (connectionSettings.expirationPeriod !== ExpirationPeriod.NONE) {
+    permissions.push(
+      `Expire connection in 1 ${connectionSettings.expirationPeriod.toLowerCase()}`,
+    );
+  }
+
   const header = (
     <Header>
       <VaspLogo src="/vasp.svg" width={32} height={32} />
@@ -179,11 +196,7 @@ export const PermissionsPage = ({ appId, clientAppDefaultSettings }: Props) => {
           </AppSection>
           <Permissions>
             <Label size="Large" content="Would like to" />
-            <PermissionsList
-              permissions={connectionSettings.permissionStates
-                .filter((permissionState) => permissionState.enabled)
-                .map((permissionState) => permissionState.permission)}
-            />
+            <PermissionsList permissions={permissions} />
           </Permissions>
         </PermissionsDescription>
         <Personalize onClick={handleShowPersonalize}>


### PR DESCRIPTION
- if no spend limit or expiration:
![Screenshot 2024-07-29 at 2 08 56 PM](https://github.com/user-attachments/assets/5cf0ee56-a1d6-4953-8db7-6de1dbcc0158)

- if has spend limit and no expiration:
![Screenshot 2024-07-29 at 2 09 04 PM](https://github.com/user-attachments/assets/ef900faa-84cc-4197-a92a-848166f76312)

- if has spend limit and expiration
![Screenshot 2024-07-29 at 2 09 13 PM](https://github.com/user-attachments/assets/3223e79f-5219-488a-828b-996625d15c47)
