### PR TITLE
[frontend] use PermissionsPage for updating connections and add loaders for PermissionPage data

### DIFF
--- a/nwc-frontend/src/Root.tsx
+++ b/nwc-frontend/src/Root.tsx
@@ -9,6 +9,8 @@ import ConnectionPage from "./connections/ConnectionPage";
 import ManualConnectionPage from "./connections/ManualConnectionPage";
 import { GlobalStyles } from "./GlobalStyles";
 import { LayoutInnerContent } from "./LayoutInnerContent";
+import { permissionsPageData } from "./loaders/permissionPageData";
+import { permissionsPageDataFromUrl } from "./loaders/permissionPageDataFromUrl";
 import { userCurrencies } from "./loaders/userCurrencies";
 import { Nav } from "./Nav";
 import { NotificationLayout } from "./NotificationLayout";
@@ -21,22 +23,28 @@ const router = createBrowserRouter([
   },
   {
     element: <ConnectionLayout />,
+    path: "/connection",
     children: [
       {
-        path: "/connection/:connectionId",
+        path: ":connectionId",
         element: <ConnectionPage />,
       },
       {
-        path: "/connection/new",
+        path: "new",
         element: <ManualConnectionPage />,
         loader: userCurrencies,
+      },
+      {
+        path: "update/:connectionId",
+        element: <PermissionsPage />,
+        loader: permissionsPageData,
       },
     ],
   },
   {
     path: "/apps/new",
     element: <PermissionsPage />,
-    loader: userCurrencies,
+    loader: permissionsPageDataFromUrl,
   },
 ]);
 

--- a/nwc-frontend/src/connections/ConnectionHeader.tsx
+++ b/nwc-frontend/src/connections/ConnectionHeader.tsx
@@ -2,6 +2,7 @@ import styled from "@emotion/styled";
 import { Button, Modal } from "@lightsparkdev/ui/components";
 import { Spacing } from "@lightsparkdev/ui/styles/tokens/spacing";
 import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { Avatar } from "src/components/Avatar";
 import { useAppInfo } from "src/hooks/useAppInfo";
 import { useGlobalNotificationContext } from "src/hooks/useGlobalNotificationContext";
@@ -15,12 +16,17 @@ export const ConnectionHeader = ({
   connection: Connection;
   updateConnection: (connection: Connection) => Promise<boolean>;
 }) => {
+  const navigate = useNavigate();
   const [isDisconnectModalVisible, setIsDisconnectModalVisible] =
     useState<boolean>(false);
   const { setSuccessMessage, setError } = useGlobalNotificationContext();
   const { appInfo, isLoading: isLoadingAppInfo } = useAppInfo({
     clientId: connection.clientId,
   });
+
+  const handleEdit = () => {
+    navigate(`/connection/update/${connection.connectionId}`);
+  };
 
   const handleDisconnect = () => {
     setIsDisconnectModalVisible(false);
@@ -61,11 +67,20 @@ export const ConnectionHeader = ({
           </AppDetails>
         </AppSection>
         {connection.status === ConnectionStatus.ACTIVE ? (
-          <Button
-            text="Disconnect"
-            icon="Remove"
-            onClick={() => setIsDisconnectModalVisible(true)}
-          />
+          <Buttons>
+            <Button
+              kind="primary"
+              icon="Restart"
+              iconSide="left"
+              text="Update"
+              onClick={handleEdit}
+            />
+            <Button
+              text="Disconnect"
+              icon="Remove"
+              onClick={() => setIsDisconnectModalVisible(true)}
+            />
+          </Buttons>
         ) : null}
       </AppAndDisconnect>
 
@@ -120,4 +135,10 @@ const AppDescription = styled.span`
   font-size: 16px;
   font-weight: 400;
   line-height: 24px;
+`;
+
+const Buttons = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: ${Spacing.sm};
 `;

--- a/nwc-frontend/src/connections/ConnectionPage.tsx
+++ b/nwc-frontend/src/connections/ConnectionPage.tsx
@@ -1,15 +1,12 @@
 import styled from "@emotion/styled";
-import { Button } from "@lightsparkdev/ui/components";
 import { Title } from "@lightsparkdev/ui/components/typography/Title";
 import { colors } from "@lightsparkdev/ui/styles/colors";
 import { Spacing } from "@lightsparkdev/ui/styles/tokens/spacing";
-import { useState } from "react";
 import { useParams } from "react-router-dom";
 import { Shimmer } from "src/components/Shimmer";
 import { TransactionTable } from "src/components/TransactionTable";
 import { useConnection } from "src/hooks/useConnection";
 import { useGlobalNotificationContext } from "src/hooks/useGlobalNotificationContext";
-import { EditLimit } from "src/permissions/EditLimit";
 import { PermissionsList } from "src/permissions/PermissionsList";
 import { ConnectionStatus } from "src/types/Connection";
 import { ConnectionHeader } from "./ConnectionHeader";
@@ -23,40 +20,7 @@ export default function ConnectionPage() {
     updateConnection,
     isLoading: isLoadingConnection,
   } = useConnection({ connectionId });
-  const [isEditLimitVisible, setIsEditLimitVisible] = useState<boolean>(false);
   const { setSuccessMessage, setError } = useGlobalNotificationContext();
-
-  const handleEdit = () => {
-    setIsEditLimitVisible(true);
-  };
-
-  const handleSubmitEditLimit = ({
-    amountInLowestDenom,
-    frequency,
-    enabled,
-  }: {
-    amountInLowestDenom: number;
-    frequency: LimitFrequency;
-    enabled: boolean;
-  }) => {
-    updateConnection({
-      amountInLowestDenom,
-      limitFrequency: frequency,
-      limitEnabled: enabled,
-      status: connection?.status,
-    })
-      .then((succeeded) => {
-        if (succeeded) {
-          setSuccessMessage("Spending limit updated successfully");
-        } else {
-          setError(new Error("Failed to update spending limit"));
-        }
-      })
-      .catch((e) => {
-        setError(e);
-      });
-    setIsEditLimitVisible(false);
-  };
 
   if (connection?.status === ConnectionStatus.PENDING) {
     return (
@@ -90,15 +54,6 @@ export default function ConnectionPage() {
             <Section>
               <SectionHeader>
                 <Title content="Spending limit" />
-                <Button
-                  kind="ghost"
-                  icon="Pencil"
-                  iconSide="left"
-                  text="Edit"
-                  onClick={handleEdit}
-                  disabled={isLoadingConnection}
-                  typography={{ color: "blue39" }}
-                />
               </SectionHeader>
               {isLoadingConnection ? (
                 <Shimmer width={200} height={20} />
@@ -113,18 +68,6 @@ export default function ConnectionPage() {
           <TransactionTable connectionId={connectionId} />
         </Section>
       </Content>
-      {isLoadingConnection ? null : (
-        <EditLimit
-          title="Edit spending limit"
-          visible={isEditLimitVisible}
-          amountInLowestDenom={connection.amountInLowestDenom}
-          currency={connection.currency}
-          frequency={connection.limitFrequency}
-          enabled={connection?.limitEnabled}
-          handleCancel={() => setIsEditLimitVisible(false)}
-          handleSubmit={handleSubmitEditLimit}
-        />
-      )}
     </>
   );
 }

--- a/nwc-frontend/src/connections/ManualConnectionPage.tsx
+++ b/nwc-frontend/src/connections/ManualConnectionPage.tsx
@@ -15,9 +15,12 @@ import { userCurrencies } from "src/loaders/userCurrencies";
 import { EditExpiration } from "src/permissions/EditExpiration";
 import { EditLimit } from "src/permissions/EditLimit";
 import { PermissionsEditableList } from "src/permissions/PermissionsEditableList";
-import { DEFAULT_CONNECTION_SETTINGS } from "src/permissions/PermissionsPage";
 import { ConnectionSettings } from "src/permissions/PersonalizePage";
-import { ExpirationPeriod, PermissionState } from "src/types/Connection";
+import {
+  DEFAULT_CONNECTION_SETTINGS,
+  ExpirationPeriod,
+  PermissionState,
+} from "src/types/Connection";
 import { formatConnectionString } from "src/utils/formatConnectionString";
 import { ManualConnectionHowItWorksModal } from "./ManualConnectionHowItWorksModal";
 import { PendingConnectionPage } from "./PendingConnectionPage";

--- a/nwc-frontend/src/connections/Nav.tsx
+++ b/nwc-frontend/src/connections/Nav.tsx
@@ -1,28 +1,20 @@
-import styled from "@emotion/styled";
-import { Icon } from "@lightsparkdev/ui/components";
-import { Link } from "react-router-dom";
+import { Button } from "@lightsparkdev/ui/components";
+import { useNavigate } from "react-router-dom";
 
 export const Nav = () => {
+  const navigate = useNavigate();
+
+  const handleBack = () => {
+    navigate("/");
+  };
+
   return (
-    <Navigation to="/">
-      <Icon name="ChevronLeft" width={12} />
-      <Text>Back to Connections</Text>
-    </Navigation>
+    <Button
+      kind="ghost"
+      icon="ChevronLeft"
+      text="Back to Connections"
+      onClick={handleBack}
+      typography={{ color: "blue39" }}
+    />
   );
 };
-
-const Navigation = styled(Link)`
-  display: flex;
-  align-items: center;
-  gap: 8px;
-`;
-
-const Text = styled.span`
-  color: ${({ theme }) => theme.link};
-  text-align: center;
-  font-size: 17px;
-  font-style: normal;
-  font-weight: 400;
-  line-height: 22px; /* 129.412% */
-  letter-spacing: -0.212px;
-`;

--- a/nwc-frontend/src/hooks/useAppInfo.ts
+++ b/nwc-frontend/src/hooks/useAppInfo.ts
@@ -1,25 +1,32 @@
 import { useEffect, useState } from "react";
 import { AppInfo } from "src/types/AppInfo";
 
+export const fetchAppInfo = async (clientId: string) => {
+  // const response = await fetch("/app", { method: "GET", body: JSON.stringify({ clientId }) });
+  // const appInfo = await response.json();
+  const appInfo = {
+    clientId,
+    name: "Cool App",
+    verified: true,
+    domain: "coolapp.com",
+    avatar: "/default-app-logo.svg",
+  };
+  return appInfo;
+};
+
 export const useAppInfo = ({ clientId }: { clientId: string }) => {
   const [appInfo, setAppInfo] = useState<AppInfo>();
   const [isLoading, setIsLoading] = useState<boolean>(true);
 
   useEffect(() => {
     // eslint-disable-next-line @typescript-eslint/require-await
-    async function fetchAppInfo() {
+    async function fetchAppInfoInternal() {
+      setIsLoading(true);
       try {
-        // const response = await fetch("/app");
-        // const appInfo = await response.json();
-        setIsLoading(true);
-        const appInfo = {
-          clientId,
-          name: "Cool App",
-          verified: true,
-          domain: "coolapp.com",
-          avatar: "/default-app-logo.svg",
-        };
-        setAppInfo(appInfo);
+        const appInfo = await fetchAppInfo(clientId);
+        if (!ignore) {
+          setAppInfo(appInfo);
+        }
       } catch (e) {
         console.error(e);
       }
@@ -28,7 +35,8 @@ export const useAppInfo = ({ clientId }: { clientId: string }) => {
     }
 
     let ignore = false;
-    fetchAppInfo();
+
+    fetchAppInfoInternal();
     return () => {
       ignore = true;
     };

--- a/nwc-frontend/src/hooks/useConnection.ts
+++ b/nwc-frontend/src/hooks/useConnection.ts
@@ -15,7 +15,7 @@ export const useConnection = ({ connectionId }: { connectionId: string }) => {
     // eslint-disable-next-line @typescript-eslint/require-await
     async function fetchConnection() {
       try {
-        // const response = await fetch("/connection");
+        // const response = await fetch(`/connection/${connectionId}`);
         // const connection = await response.json();
         setIsLoading(true);
         const connection = MOCKED_CONNECTIONS.find(
@@ -76,6 +76,33 @@ export const useConnection = ({ connectionId }: { connectionId: string }) => {
     isLoading,
     updateConnection,
   };
+};
+
+// eslint-disable-next-line @typescript-eslint/require-await
+export const updateConnection = async ({
+  connectionId,
+  amountInLowestDenom,
+  limitFrequency,
+  limitEnabled,
+  expiration,
+  status,
+}: {
+  connectionId: string;
+  amountInLowestDenom: number;
+  limitFrequency: LimitFrequency;
+  limitEnabled: boolean;
+  expiration: string;
+  status: ConnectionStatus;
+}) => {
+  try {
+    // const response = await fetch("/connection", {
+    //   method: "POST",
+    //   body: JSON.stringify({ connectionId: connectionId, amountInLowestDenom, limitFrequency, limitEnabled, expiration, status }),
+    // });
+    return true;
+  } catch (e) {
+    return { error: e };
+  }
 };
 
 // eslint-disable-next-line @typescript-eslint/require-await

--- a/nwc-frontend/src/hooks/useUma.ts
+++ b/nwc-frontend/src/hooks/useUma.ts
@@ -1,5 +1,20 @@
 import { useEffect, useState } from "react";
 
+export const fetchUma = async () => {
+  // const uma = await fetch(`${getBackendUrl()}/uma`, {
+  //   method: "GET",
+  //   cache: "force-cache",
+  // }).then((res) => {
+  //   if (res.ok) {
+  //     return res.json() as Promise<{ uma: string }>;
+  //   } else {
+  //     throw new Error("Failed to fetch uma.");
+  //   }
+  // });
+  const response = { uma: "$test@vasp.com" };
+  return response.uma;
+};
+
 export function useUma() {
   const [uma, setUma] = useState<string>();
   const [error, setError] = useState<string>();
@@ -7,22 +22,12 @@ export function useUma() {
 
   useEffect(() => {
     // eslint-disable-next-line @typescript-eslint/require-await
-    async function fetchUma() {
+    async function fetchUmaInternal() {
       setIsLoading(true);
       try {
-        // const response = await fetch(`${getBackendUrl()}/uma`, {
-        //   method: "GET",
-        //   cache: "force-cache",
-        // }).then((res) => {
-        //   if (res.ok) {
-        //     return res.json() as Promise<{ uma: string }>;
-        //   } else {
-        //     throw new Error("Failed to fetch uma.");
-        //   }
-        // });
-        const response = { uma: "$test@vasp.com" };
+        const uma = await fetchUma();
         if (!ignore) {
-          setUma(response.uma);
+          setUma(uma);
           setIsLoading(false);
         }
       } catch (e: unknown) {
@@ -33,7 +38,7 @@ export function useUma() {
     }
 
     let ignore = false;
-    fetchUma();
+    fetchUmaInternal();
     return () => {
       ignore = true;
     };

--- a/nwc-frontend/src/loaders/permissionPageData.ts
+++ b/nwc-frontend/src/loaders/permissionPageData.ts
@@ -1,0 +1,69 @@
+import { json, LoaderFunction } from "react-router-dom";
+import { fetchAppInfo } from "src/hooks/useAppInfo";
+import { fetchUma } from "src/hooks/useUma";
+import { Connection, DEFAULT_CONNECTION_SETTINGS } from "src/types/Connection";
+import { PermissionPageLoaderData } from "src/types/PermissionPageLoaderData";
+import { MOCKED_CONNECTIONS } from "src/utils/fetchConnections";
+
+export interface InitialPermissionsResponse {
+  defaultCurrency: Currency;
+  currencies: Currency[];
+}
+
+const getConnectionSettings = (connection: Connection) => {
+  const permissionStates = connection.permissions.map((permission) => ({
+    permission,
+    enabled: true,
+  }));
+
+  return {
+    permissionStates,
+    amountInLowestDenom: connection.amountInLowestDenom,
+    limitFrequency: connection.limitFrequency,
+    limitEnabled: connection.limitEnabled,
+    expirationPeriod: DEFAULT_CONNECTION_SETTINGS.expirationPeriod,
+  };
+};
+
+export const permissionsPageData = (async ({ params }) => {
+  // const response = await fetch(`/connection/${params.connectionId}`);
+  // const connection = await response.json();
+  const connection = MOCKED_CONNECTIONS.find(
+    (c) => c.connectionId === params.connectionId,
+  );
+
+  if (!connection) {
+    throw new Response("Connection not found", { status: 404 });
+  }
+
+  // const { defaultCurrency } =  await fetch(
+  //   "/user/currencies",
+  //   {
+  //     method: "GET",
+  //   },
+  // );
+
+  const defaultCurrency = {
+    code: "USD",
+    name: "United States Dollar",
+    symbol: "$",
+    decimals: 2,
+    type: "fiat",
+  };
+
+  const [appInfo, uma] = await Promise.all([
+    fetchAppInfo(connection.clientId),
+    fetchUma(),
+  ]);
+
+  return json(
+    {
+      appInfo,
+      uma,
+      connectionSettings: getConnectionSettings(connection),
+      defaultCurrency,
+      connection,
+    } as PermissionPageLoaderData,
+    { status: 200 },
+  );
+}) satisfies LoaderFunction;

--- a/nwc-frontend/src/loaders/permissionPageDataFromUrl.ts
+++ b/nwc-frontend/src/loaders/permissionPageDataFromUrl.ts
@@ -1,0 +1,126 @@
+import { json, LoaderFunction } from "react-router-dom";
+import { fetchAppInfo } from "src/hooks/useAppInfo";
+import { fetchUma } from "src/hooks/useUma";
+import {
+  DEFAULT_CONNECTION_SETTINGS,
+  PERMISSION_DESCRIPTIONS,
+  PermissionType,
+} from "src/types/Connection";
+import { PermissionPageLoaderData } from "src/types/PermissionPageLoaderData";
+
+export interface InitialPermissionsResponse {
+  defaultCurrency: Currency;
+  currencies: Currency[];
+}
+
+const getClientAppDefaultSettings = ({
+  requiredCommands,
+  optionalCommands,
+  budget,
+  expirationPeriod,
+}) => {
+  const requiredPermissionStates = requiredCommands
+    .split(",")
+    .map((command) => ({
+      permission: {
+        type: command.toUpperCase() as PermissionType,
+        description: PERMISSION_DESCRIPTIONS[command.toLowerCase()],
+        optional: false,
+      },
+      enabled: true,
+    }));
+  const optionalPermissionStates = optionalCommands
+    .split(",")
+    .map((command) => ({
+      permission: {
+        type: command.toUpperCase() as PermissionType,
+        description: PERMISSION_DESCRIPTIONS[command.toLowerCase()],
+        optional: true,
+      },
+      enabled: false,
+    }));
+  const permissionStates = requiredPermissionStates.concat(
+    optionalPermissionStates,
+  );
+  let [amountCurrency, limitFrequency] = budget.split("/");
+  let [amountInLowestDenom, currencyCode] = amountCurrency.split(".");
+
+  if (permissionStates.length === 0) {
+    permissionStates.concat(DEFAULT_CONNECTION_SETTINGS.permissionStates);
+  }
+
+  if (!amountInLowestDenom) {
+    amountInLowestDenom = DEFAULT_CONNECTION_SETTINGS.amountInLowestDenom;
+  }
+
+  if (!currencyCode) {
+    currencyCode = "SAT";
+  }
+
+  if (!limitFrequency) {
+    limitFrequency = DEFAULT_CONNECTION_SETTINGS.limitFrequency;
+  }
+
+  if (!expirationPeriod) {
+    expirationPeriod = DEFAULT_CONNECTION_SETTINGS.expirationPeriod;
+  }
+
+  // TODO: perform rough currency conversion to user's home currency
+
+  return {
+    permissionStates,
+    amountInLowestDenom,
+    limitFrequency,
+    limitEnabled: DEFAULT_CONNECTION_SETTINGS.limitEnabled,
+    expirationPeriod,
+  };
+};
+
+export const permissionsPageDataFromUrl = (async ({ request }) => {
+  const url = new URL(request.url);
+  const params = url.searchParams;
+  const oauthParams = {
+    clientId: params.get("client_id"),
+    redirectUri: params.get("redirect_uri"),
+    responseType: params.get("response_type"),
+    codeChallenge: params.get("code_challenge"),
+    codeChallengeMethod: params.get("code_challenge_method"),
+  };
+  const nwcParams = {
+    requiredCommands: params.get("required_commands"),
+    optionalCommands: params.get("optional_commands"),
+    budget: params.get("budget"),
+    expirationPeriod: params.get("expiration_period"),
+  };
+
+  // const { defaultCurrency } =  await fetch(
+  //   "/user/currencies",
+  //   {
+  //     method: "GET",
+  //   },
+  // );
+
+  const defaultCurrency = {
+    code: "USD",
+    name: "United States Dollar",
+    symbol: "$",
+    decimals: 2,
+    type: "fiat",
+  };
+
+  const [appInfo, uma] = await Promise.all([
+    fetchAppInfo(oauthParams.clientId),
+    fetchUma(),
+  ]);
+
+  return json(
+    {
+      appInfo,
+      uma,
+      connectionSettings: getClientAppDefaultSettings(nwcParams),
+      defaultCurrency,
+      oauthParams,
+    } as PermissionPageLoaderData,
+    { status: 200 },
+  );
+}) satisfies LoaderFunction;

--- a/nwc-frontend/src/types/Connection.ts
+++ b/nwc-frontend/src/types/Connection.ts
@@ -70,3 +70,35 @@ export interface Connection {
   lastUsed?: string;
   disconnectedAt?: string;
 }
+
+export const DEFAULT_CONNECTION_SETTINGS: ConnectionSettings = {
+  permissionStates: [
+    {
+      permission: {
+        type: PermissionType.SEND_PAYMENTS,
+        description: "Send payments from your UMA",
+      },
+      enabled: true,
+    },
+    {
+      permission: {
+        type: PermissionType.READ_BALANCE,
+        description: "Read your balance",
+        optional: true,
+      },
+      enabled: false,
+    },
+    {
+      permission: {
+        type: PermissionType.READ_TRANSACTIONS,
+        description: "Read transaction history",
+        optional: true,
+      },
+      enabled: false,
+    },
+  ],
+  amountInLowestDenom: 50000,
+  limitFrequency: LimitFrequency.NONE,
+  limitEnabled: true,
+  expirationPeriod: ExpirationPeriod.YEAR,
+};

--- a/nwc-frontend/src/types/PermissionPageLoaderData.ts
+++ b/nwc-frontend/src/types/PermissionPageLoaderData.ts
@@ -1,0 +1,29 @@
+import { ConnectionSettings } from "src/permissions/PersonalizePage";
+import { AppInfo } from "./AppInfo";
+import { Connection } from "./Connection";
+import { Currency } from "./Currency";
+
+interface LoaderDataBase {
+  appInfo: AppInfo;
+  uma: string;
+  connectionSettings: ConnectionSettings;
+  defaultCurrency: Currency;
+}
+
+interface LoaderDataFromUrl extends LoaderDataBase {
+  oauthParams: {
+    clientId: string;
+    redirectUri: string;
+    responseType: string;
+    codeChallenge: string;
+    codeChallengeMethod: string;
+  };
+}
+
+interface LoaderDataFromConnection extends LoaderDataBase {
+  connection: Connection;
+}
+
+export type PermissionPageLoaderData =
+  | LoaderDataFromUrl
+  | LoaderDataFromConnection;


### PR DESCRIPTION
- adds Update button instead of editing individual limit
![Screenshot 2024-08-07 at 4.24.12 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/NU8OmLauzLqa61yWDJkY/4036174d-d74b-4da5-bb13-c3e2c4704031.png)

- uses permissions page for updating existing connections
- adds two separate routes and loaders depending on if the PermissionsPage is accessed via initial connection url or is an existing connection
![Screenshot 2024-08-07 at 4.24.15 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/NU8OmLauzLqa61yWDJkY/7f77311b-c3e9-41d8-8f02-8c393e68c524.png)

