### PR TITLE
Using db_session.get to query with primary key

### DIFF
--- a/nwc_backend/__init__.py
+++ b/nwc_backend/__init__.py
@@ -144,8 +144,8 @@ def create_app() -> Quart:
 
         # save the long lived token in the db and create the app connection
         with Session(db.engine) as db_session:
-            nwc_connection: NWCConnection = db_session.query(NWCConnection).get(
-                nw_connection_id
+            nwc_connection: NWCConnection = db_session.get(
+                NWCConnection, nw_connection_id
             )
 
             # exhange the short lived jwt for a long lived jwt

--- a/nwc_backend/models/__tests__/app_connection_test.py
+++ b/nwc_backend/models/__tests__/app_connection_test.py
@@ -41,7 +41,7 @@ async def test_app_connection_model(test_client: QuartClient) -> None:
         db_session.commit()
 
     with Session(db.engine) as db_session:
-        app_connection = db_session.query(AppConnection).get(id)
+        app_connection = db_session.get(AppConnection, id)
         assert isinstance(app_connection, AppConnection)
         assert app_connection.has_command_permission(Nip47RequestMethod.FETCH_QUOTE)
         assert not app_connection.has_command_permission(

--- a/nwc_backend/models/__tests__/client_app_test.py
+++ b/nwc_backend/models/__tests__/client_app_test.py
@@ -30,7 +30,7 @@ async def test_client_app_model(test_client: QuartClient) -> None:
         db_session.commit()
 
     with Session(db.engine) as db_session:
-        client_app = db_session.query(ClientApp).get(id)
+        client_app = db_session.get(ClientApp, id)
         assert isinstance(client_app, ClientApp)
         assert client_app.client_id == client_id
         assert client_app.app_name == app_name
@@ -46,6 +46,6 @@ async def test_client_app_model(test_client: QuartClient) -> None:
         db_session.commit()
 
     with Session(db.engine) as db_session:
-        client_app = db_session.query(ClientApp).get(id)
+        client_app = db_session.get(ClientApp, id)
         assert isinstance(client_app, ClientApp)
         assert client_app.logo_uri == logo_uri

--- a/nwc_backend/models/__tests__/nip47_request_test.py
+++ b/nwc_backend/models/__tests__/nip47_request_test.py
@@ -38,7 +38,7 @@ async def test_nip47_request_model(test_client: QuartClient) -> None:
         db_session.commit()
 
     with Session(db.engine) as db_session:
-        nip47_request = db_session.query(Nip47Request).get(id)
+        nip47_request = db_session.get(Nip47Request, id)
         assert isinstance(nip47_request, Nip47Request)
         assert nip47_request.event_id == event_id
         assert nip47_request.app_connection_id == app_connection_id

--- a/nwc_backend/models/__tests__/nwc_connection_test.py
+++ b/nwc_backend/models/__tests__/nwc_connection_test.py
@@ -29,7 +29,7 @@ async def test_nwc_connection_model(test_client: QuartClient) -> None:
         db_session.commit()
 
     with Session(db.engine) as db_session:
-        nwc_connection = db_session.query(NWCConnection).get(id)
+        nwc_connection = db_session.get(NWCConnection, id)
         assert isinstance(nwc_connection, NWCConnection)
         assert nwc_connection.user.id == user_id
         assert nwc_connection.client_app.id == client_app_id


### PR DESCRIPTION
Just noticed warnings when running tests saying that db_session.query to query with primary key is deprecated