### PR TITLE
Use async db driver

### DIFF
--- a/nwc_backend/configs/local_dev.py
+++ b/nwc_backend/configs/local_dev.py
@@ -4,7 +4,7 @@
 import os
 import secrets
 
-DATABASE_URI: str = "sqlite+pysqlite:///" + os.path.join(
+DATABASE_URI: str = "sqlite+aiosqlite:///" + os.path.join(
     os.getcwd(), "instance", "nwc.sqlite"
 )
 

--- a/nwc_backend/configs/local_docker.py
+++ b/nwc_backend/configs/local_docker.py
@@ -4,7 +4,7 @@
 import os
 import secrets
 
-DATABASE_URI: str = "sqlite+pysqlite:///" + os.path.join(
+DATABASE_URI: str = "sqlite+aiosqlite:///" + os.path.join(
     os.getcwd(), "instance", "nwc.sqlite"
 )
 


### PR DESCRIPTION
Fix error - sqlalchemy.exc.InvalidRequestError: The asyncio extension requires an async driver to be used. The loaded 'pysqlite' is not async. 