### PR TITLE
Parse body in apps/new post

### DIFF
--- a/nwc-frontend/src/permissions/PermissionsPage.tsx
+++ b/nwc-frontend/src/permissions/PermissionsPage.tsx
@@ -39,7 +39,7 @@ async function initConnection({
     currencyCode,
     permissions: connectionSettings.permissionStates
       .filter((permissionState) => permissionState.enabled)
-      .map((permissionState) => permissionState.permission),
+      .map((permissionState) => permissionState.permission.type),
     amountInLowestDenom: connectionSettings.amountInLowestDenom,
     limitFrequency: connectionSettings.limitFrequency,
     limitEnabled: connectionSettings.limitEnabled,

--- a/nwc-frontend/src/types/Connection.ts
+++ b/nwc-frontend/src/types/Connection.ts
@@ -45,7 +45,7 @@ export enum ConnectionStatus {
 
 export interface InitialConnection {
   name: string;
-  permissions: Permission[];
+  permissions: PermissionType[];
   currencyCode: string;
   amountInLowestDenom: number;
   limitEnabled: boolean;

--- a/nwc_backend/models/permissions_grouping.py
+++ b/nwc_backend/models/permissions_grouping.py
@@ -1,0 +1,54 @@
+from enum import Enum
+from nwc_backend.models.nip47_request_method import Nip47RequestMethod
+
+
+class PermissionsGroup(Enum):
+    SEND_PAYMENTS = "send_payments"
+    READ_BALANCE = "read_balance"
+    READ_TRANSACTIONS = "read_transactions"
+    RECEIVE_PAYMENTS = "receive_payments"
+    ALWAYS_GRANTED = "always_granted"
+
+
+METHOD_TO_PERMISSIONS_GROUP = {
+    Nip47RequestMethod.MAKE_INVOICE.value: PermissionsGroup.RECEIVE_PAYMENTS,
+    Nip47RequestMethod.GET_BALANCE.value: PermissionsGroup.READ_BALANCE,
+    Nip47RequestMethod.PAY_KEYSEND.value: PermissionsGroup.SEND_PAYMENTS,
+    Nip47RequestMethod.PAY_INVOICE.value: PermissionsGroup.SEND_PAYMENTS,
+    Nip47RequestMethod.FETCH_QUOTE.value: PermissionsGroup.SEND_PAYMENTS,
+    Nip47RequestMethod.EXECUTE_QUOTE.value: PermissionsGroup.SEND_PAYMENTS,
+    Nip47RequestMethod.PAY_TO_ADDRESS.value: PermissionsGroup.SEND_PAYMENTS,
+    Nip47RequestMethod.LOOKUP_INVOICE.value: PermissionsGroup.READ_TRANSACTIONS,
+    Nip47RequestMethod.LIST_TRANSACTIONS.value: PermissionsGroup.READ_TRANSACTIONS,
+    Nip47RequestMethod.LOOKUP_USER.value: PermissionsGroup.ALWAYS_GRANTED,
+    Nip47RequestMethod.GET_INFO.value: PermissionsGroup.ALWAYS_GRANTED,
+    # groups map to themselves
+    PermissionsGroup.SEND_PAYMENTS.value: PermissionsGroup.SEND_PAYMENTS,
+    PermissionsGroup.RECEIVE_PAYMENTS.value: PermissionsGroup.RECEIVE_PAYMENTS,
+    PermissionsGroup.READ_BALANCE.value: PermissionsGroup.READ_BALANCE,
+    PermissionsGroup.READ_TRANSACTIONS.value: PermissionsGroup.READ_TRANSACTIONS,
+}
+
+PERMISSIONS_GROUP_TO_METHODS = {
+    PermissionsGroup.RECEIVE_PAYMENTS: [
+        Nip47RequestMethod.MAKE_INVOICE.value,
+    ],
+    PermissionsGroup.SEND_PAYMENTS: [
+        Nip47RequestMethod.PAY_INVOICE.value,
+        Nip47RequestMethod.PAY_KEYSEND.value,
+        Nip47RequestMethod.EXECUTE_QUOTE.value,
+        Nip47RequestMethod.PAY_TO_ADDRESS.value,
+        Nip47RequestMethod.FETCH_QUOTE.value,
+    ],
+    PermissionsGroup.READ_BALANCE: [
+        Nip47RequestMethod.GET_BALANCE.value,
+    ],
+    PermissionsGroup.READ_TRANSACTIONS: [
+        Nip47RequestMethod.LIST_TRANSACTIONS.value,
+        Nip47RequestMethod.LOOKUP_INVOICE.value,
+    ],
+    PermissionsGroup.ALWAYS_GRANTED: [
+        Nip47RequestMethod.LOOKUP_USER.value,
+        Nip47RequestMethod.GET_INFO.value,
+    ],
+}


### PR DESCRIPTION
reads body and integrates proposed plan for grouped permissions discussed [here](https://lightsparkgroup.slack.com/archives/C07AJ8E0Y5D/p1725489320562379) - so backend will always be saving grouped permissions. 

will update oauth/auth to also save grouped permissions in DB and send them to NWC FE in a follow up PR. 

