### PR TITLE
Revert "Support sslmode and sslrootcert for RDS connections"

### DIFF
--- a/nwc_backend/db.py
+++ b/nwc_backend/db.py
@@ -1,7 +1,6 @@
 # pyre-strict
 
 import asyncio
-import ssl
 import uuid
 from datetime import datetime, timezone
 from time import monotonic
@@ -142,20 +141,6 @@ def setup_rds_iam_auth(engine: AsyncEngine) -> None:
             token_cache.clear()
             token_cache.extend((monotonic(), token))
         cparams["password"] = token_cache[1]
-
-        # SQLAlchemy converts the URL to connect() arguments, but asyncpg
-        # only accepts sslmode et al. in a URL, not as arguments. So we
-        # need to construct an SSL context instead.
-        if "ssl" not in cparams:
-            sslmode = cparams.pop("sslmode", "prefer")
-            if sslmode in {"disable", "prefer", "allow", "require"}:
-                cparams["ssl"] = sslmode
-            else:
-                sslctx = ssl.create_default_context(
-                    ssl.Purpose.SERVER_AUTH, cafile=cparams.pop("sslrootcert", None)
-                )
-                sslctx.check_hostname = sslmode == "verify-full"
-                cparams["ssl"] = sslctx
 
     @event.listens_for(engine.sync_engine, "connect", named=True)
     def set_timeout(


### PR DESCRIPTION
Reverts uma-universal-money-address/uma-nwc-server#208

This seems to have broken psycopg connection strings like the one used in pinkdrink. I think we just need to have the ssl params in the connection string like we do elsewhere. I'll need to chat with @mgorven about that on Monday.